### PR TITLE
Lock versions in Pipenv file

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,14 +4,14 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-wagtail = "*"
-wagtail-autocomplete = "*"
-faker = "*"
+wagtail = "==2.5.1"
+wagtail-autocomplete = "==0.3.1"
+faker = "==1.0.7"
 factory-boy = "==2.11.1"
-wagtail-factories = "*"
-gunicorn = "*"
-django-el-pagination = "*"
-wagtailmenus = "*"
+wagtail-factories = "==1.1.0"
+gunicorn = "==19.9.0"
+django-el-pagination = "==3.2.4"
+wagtailmenus = "==2.13.1"
 psycopg2-binary = "==2.8.3"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "61d2e3294d204c3794fa051c585fa92ef99ee83f47ca51fb57b388e4fdad34b2"
+            "sha256": "cfc76c8ee896d6d43c290063e217ab70ef75f18bed1f00941d5ccf0664164b8e"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
This is done to make Pipenv a bit more deterministic...

This follows from NPM's way of doing things. Pyup bot will be used to
update these main, top-level, packages as needed.